### PR TITLE
Standardize API Response Model Across the Entire Application

### DIFF
--- a/src/app/shared/services/api.service.spec.ts
+++ b/src/app/shared/services/api.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ApiService } from './api.service';
+
+describe('ApiService', () => {
+  let service: ApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/api.service.ts
+++ b/src/app/shared/services/api.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  ApiResponse,
+  ApiResponseHelper
+} from '../models/api-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiService {
+  private baseUrl = 'http://localhost:8085/api'; // Replace with your API base URL
+
+  constructor(private http: HttpClient) { }
+
+  get<T>(endpoint: string): Observable<ApiResponse<T>> {
+    return this.http.get<ApiResponse<T>>(`${this.baseUrl}/${endpoint}`);
+  }
+
+  post<T>(endpoint: string, data: any): Observable<ApiResponse<T>> {
+    return this.http.post<ApiResponse<T>>(`${this.baseUrl}/${endpoint}`, data);
+  }
+
+  put<T>(endpoint: string, data: any): Observable<ApiResponse<T>> {
+    return this.http.put<ApiResponse<T>>(`${this.baseUrl}/${endpoint}`, data);
+  }
+
+  patch<T>(endpoint: string, data: any): Observable<ApiResponse<T>> {
+    return this.http.patch<ApiResponse<T>>(`${this.baseUrl}/${endpoint}`, data);
+  }
+
+  delete<T>(endpoint: string): Observable<ApiResponse<T>> {
+    return this.http.delete<ApiResponse<T>>(`${this.baseUrl}/${endpoint}`);
+  }
+}

--- a/src/app/shared/services/base.service.spec.ts
+++ b/src/app/shared/services/base.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BaseService } from './base.service';
+
+describe('BaseService', () => {
+  let service: BaseService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BaseService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/base.service.ts
+++ b/src/app/shared/services/base.service.ts
@@ -1,0 +1,46 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiService } from './api.service';
+import { ApiResponse } from '../models/api-response.model';
+
+export abstract class BaseService<T> {
+  protected abstract endpoint: string;
+
+  constructor(protected apiService: ApiService) { }
+
+  getAll(): Observable<T[]> {
+    return this.apiService.get<T[]>(this.endpoint)
+      .pipe(
+        map(response => response.data)
+      );
+  }
+
+  getById(id: number): Observable<T> {
+    return this.apiService.get<T>(`${this.endpoint}/${id}`)
+      .pipe(
+        map(response => response.data)
+      );
+  }
+
+  create(item: any): Observable<T> {
+    return this.apiService.post<T>(this.endpoint, item)
+      .pipe(
+        map(response => response.data)
+      );
+  }
+
+  update(id: number, item: any): Observable<T> {
+    return this.apiService.put<T>(`${this.endpoint}/${id}`, item)
+      .pipe(
+        map(response => response.data)
+      );
+  }
+
+  delete(id: number): Observable<void> {
+    return this.apiService.delete<void>(`${this.endpoint}/${id}`)
+      .pipe(
+        map(response => response.data)
+      );
+  }
+
+}


### PR DESCRIPTION
- Move the ApiResponse model to the shared folder
- Update BrandService to use the common ApiResponse
- Integrate the ApiResponse model into BrandsComponent
- Improve error handling using catchError in components
- Implement full type checking for all API responses
- Adjust BrandDialogComponent to align with ApiResponse
- Ensure all HTTP requests use the unified response model