### PR TITLE
wrong

### DIFF
--- a/src/app/features/brands/brand-dialog/brand-dialog.component.html
+++ b/src/app/features/brands/brand-dialog/brand-dialog.component.html
@@ -43,8 +43,8 @@
             <mat-form-field appearance="outline">
                 <mat-label>Trạng thái</mat-label>
                 <mat-select formControlName="status">
-                    <mat-option value="active">Đang hoạt động</mat-option>
-                    <mat-option value="inactive">Ẩn</mat-option>
+                    <mat-option value="ACTIVE">Đang hoạt động</mat-option>
+                    <mat-option value="INACTIVE">Ẩn</mat-option>
                 </mat-select>
             </mat-form-field>
 

--- a/src/app/features/brands/brands.component.html
+++ b/src/app/features/brands/brands.component.html
@@ -127,8 +127,8 @@
                         <th mat-header-cell *matHeaderCellDef>Trạng thái</th>
                         <td mat-cell *matCellDef="let brand">
                             <span class="status-badge" [ngClass]="{
-                                'active': brand.status === 'ACTIVE',
-                                'inactive': brand.status === 'INACTIVE'
+                                'ACTIVE': brand.status === 'ACTIVE',
+                                'INACTIVE': brand.status === 'INACTIVE'
                             }">
                                 {{ brand.status === 'ACTIVE' ? 'Đang hoạt động' : 'Ẩn' }}
                             </span>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Standardize brand status values to use uppercase 'ACTIVE' and 'INACTIVE' constants in both HTML templates